### PR TITLE
Fix: Use access token instead of deprecated email/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ profile_prefix: "I am boosting trending posts from:"
 
 # profile fields to fill in
 fields:
-  code: https://github.com/tante/hype
+  code: https://github.com/v411e/hype
   operator: "YOUR HANDLE HERE"
 
 # Define subscribed instances and

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Create a `config.yaml` and a `auth.yaml` file in `./config/`. Enter the credenti
 # Credentials for your bot account
 bot_account:
   server: "mastodon.example.com"
-  email: "hypebot@example.com"
-  password: "averylongandsecurepassword"
+  access_token: "Create a new application in your bot account at Preferences -> Development"
 ```
 
 `config.yaml`

--- a/config/auth.yaml
+++ b/config/auth.yaml
@@ -1,5 +1,4 @@
 # Credentials for your bot account
 bot_account:
   server: ""
-  email: ""
-  password: ""
+  access_token: ""

--- a/hype/config.py
+++ b/hype/config.py
@@ -6,16 +6,14 @@ import yaml
 
 class BotAccount:
     server: str
-    email: str
-    password: str
+    access_token: str
 
-    def __init__(self, server: str, email: str, password: str) -> None:
+    def __init__(self, server: str, access_token: str) -> None:
         self.server = server
-        self.email = email
-        self.password = password
+        self.access_token = access_token
 
     def __repr__(self) -> str:
-        return f"server: {self.server}, email: {self.email}, password: {self.password}"
+        return f"server: {self.server}, access_token: {self.access_token}"
 
 
 class Instance:
@@ -53,13 +51,11 @@ class Config:
                 config
                 and config.get("bot_account")
                 and config["bot_account"].get("server")
-                and config["bot_account"].get("email")
-                and config["bot_account"].get("password")
+                and config["bot_account"].get("access_token")
             ):
                 self.bot_account = BotAccount(
                     server=config["bot_account"]["server"],
-                    email=config["bot_account"]["email"],
-                    password=config["bot_account"]["password"],
+                    access_token=config["bot_account"]["access_token"],
                 )
             else:
                 logging.getLogger("Config").error(config)

--- a/hype/hype.py
+++ b/hype/hype.py
@@ -20,13 +20,11 @@ class Hype:
         self.log.info("Config loaded")
 
     def login(self):
-        self.client = self.init_client(self.config.bot_account.server)
         self.log.info(f"Logging in to {self.config.bot_account.server}")
-        self.client.log_in(
-            self.config.bot_account.email,
-            self.config.bot_account.password,
-            to_file=f"secrets/{self.config.bot_account.server}_usercred.secret",
-        )
+        self.client = Mastodon(
+            api_base_url=self.config.bot_account.server,
+            access_token=self.config.bot_account.access_token
+          )
 
     def update_profile(self):
         self.log.info("Update bot profile")


### PR DESCRIPTION
Adds compatibility with Mastodon 4.4.0+

Closes #9 
