### PR TITLE
Version tag in docker-compose is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ For smaller instances the local timeline is rather empty. This is why trends sim
 Deploy with docker-compose
 
 ```yaml
-version: "3"
 services:
   hype:
     image: valentinriess/hype:latest


### PR DESCRIPTION
"the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion" - Docker CLI